### PR TITLE
Feature@proxy request

### DIFF
--- a/examples/mock-api.yml
+++ b/examples/mock-api.yml
@@ -1,6 +1,7 @@
 /catNames:
   GET:
     code: 200
+    type: "mock"
     payload: |
       [
         {
@@ -14,7 +15,8 @@
       ]    
 /dogNames:    
   GET:    
-    code: 200                                      
+    code: 200
+    type: "mock"                                   
     payload: |                                        
       [    
         {    
@@ -28,3 +30,9 @@
       ]    
   POST:    
     code: 201    
+
+/posts:
+  GET:
+    code: 200
+    type: "proxy"
+    payload: "https://jsonplaceholder.typicode.com/posts/"


### PR DESCRIPTION
This is a simple example of mock proxy. I modified default schema to include a "type" option. this option is used to define the type of mock endpoint, which can be "message" or "proxy". If type is "proxy", the value of "payload" must be the url to be mocked.